### PR TITLE
refactor: change regexp simpler

### DIFF
--- a/lib/masking/insert_statement.rb
+++ b/lib/masking/insert_statement.rb
@@ -39,7 +39,7 @@ module Masking
     attr_reader :columns_section, :values_section
 
     VALUE_ROW_SPLITTER = '),('
-    PARSE_REGEXP = /INSERT INTO `(?<table>.+)` \((?<columns_section>.+)\) VALUES (?<values_section>.+);/.freeze
+    PARSE_REGEXP = /INSERT INTO `(?<table>.+)` \((?<columns_section>.+)\) VALUES \((?<values_section>.+)\);/.freeze
     COLUMNS_REGEXP = /`(.*?)`/.freeze
 
     # NOTE: in mysqldump,
@@ -57,7 +57,7 @@ module Masking
     VALUE_REGEXP = "(#{NUMBER_REGEXP}|#{NULL_REGEXP}|#{STRING_TIME_REGEXP}|#{BINARY_REGEXP})"
 
     def values_regexp
-      @values_regexp ||= /^\(?#{([VALUE_REGEXP] * columns.count).join(?,)}\)?$/
+      @values_regexp ||= /^?#{([VALUE_REGEXP] * columns.count).join(?,)}?$/
     end
 
     # Check single quote count on each value, and just continue if it's even number.


### PR DESCRIPTION
 - [x] check performance improvment

## before
```
2019-01-13 masking > 23GB_sqldump.sql  11376.61s user 153.19s system 98% cpu 3:14:28.25 total
```
## after
``` 
2019-01-13 masking > 23GB_sqldump.sql > 12529.03s user 280.19s system 99% cpu 3:34:28.94 total
```
 it indicates performance decrement. 🤔 

- [ ] check more detail of performance regression. 