### PR TITLE
fix mysqldump error

### DIFF
--- a/.github/workflows/acceptance_test_mariadb.yml
+++ b/.github/workflows/acceptance_test_mariadb.yml
@@ -5,9 +5,6 @@ on:
       - main
   pull_request:
 
-env:
-  DEBUG: ${{ vars.DEBUG }}
-
 jobs:
   mariadb111:
     runs-on: ubuntu-latest
@@ -19,6 +16,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mariadb111 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mariadb110:
     runs-on: ubuntu-latest
     steps:
@@ -29,6 +27,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mariadb110 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mariadb1011:
     runs-on: ubuntu-latest
     steps:
@@ -39,6 +38,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mariadb1011 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mariadb1010:
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +49,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mariadb1010 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mariadb109:
     runs-on: ubuntu-latest
     steps:
@@ -59,6 +60,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mariadb109 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mariadb108:
     runs-on: ubuntu-latest
     steps:
@@ -69,6 +71,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mariadb108 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mariadb107:
     runs-on: ubuntu-latest
     steps:
@@ -79,6 +82,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mariadb107 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mariadb106:
     runs-on: ubuntu-latest
     steps:
@@ -89,6 +93,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mariadb106 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mariadb105:
     runs-on: ubuntu-latest
     steps:
@@ -99,6 +104,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mariadb105 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mariadb104:
     runs-on: ubuntu-latest
     steps:
@@ -109,6 +115,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mariadb104 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mariadb103:
     runs-on: ubuntu-latest
     steps:
@@ -119,6 +126,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mariadb103 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mariadb102:
     runs-on: ubuntu-latest
     steps:
@@ -129,3 +137,4 @@ jobs:
         run: docker-compose/acceptance_test.sh mariadb102 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}

--- a/.github/workflows/acceptance_test_mysql.yml
+++ b/.github/workflows/acceptance_test_mysql.yml
@@ -16,6 +16,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mysql81 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mysql80:
     runs-on: ubuntu-latest
     steps:
@@ -26,6 +27,7 @@ jobs:
         run: docker-compose/acceptance_test.sh mysql80 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}
   mysql57:
     runs-on: ubuntu-latest
     steps:
@@ -36,3 +38,4 @@ jobs:
         run: docker-compose/acceptance_test.sh mysql57 docker-compose-ci.yml
         env:
           TRACE: ${{ vars.TRACE }}
+          DUMPFILE_DEBUG: ${{ vars.DUMPFILE_DEBUG }}

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ available option via environment variable:
 * `MYSQL_PASSWORD`: password for user(default: `password`)
 * `MYSQL_DBNAME`: database name(default: `mydb`)
 
-NOTE: run with `TRACE=1` will show debug print. for the CI, `TRACE` environment variable on [setting field in the repository](https://github.com/kibitan/masking/settings/variables/actions/TRACE)
+NOTE: run with `TRACE=1` will show debug print. for the CI, `TRACE` environment variable on [setting field in the repository](https://github.com/kibitan/masking/settings/variables/actions/TRACE) and run with `DUMPFILE_DEBUG=1` will show dumpfile to stdout, [setting field in the repository](https://github.com/kibitan/masking/settings/variables/actions/DUMPFILE_DEBUG)
 
 ##### with docker-compose
 

--- a/acceptance/run_test.sh
+++ b/acceptance/run_test.sh
@@ -23,9 +23,7 @@ main() {
   mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" < "$FILEDIR/import_dumpfile.sql"
 
   #  masking & restore
-  ## TODO: temporary add `--skip-extended-insert` as not working now
-  # mysqldump -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" --complete-insert | exe/masking -c "$FILEDIR/masking.yml" > "$FILEDIR/tmp/masking_dumpfile.sql"
-  mysqldump -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" --complete-insert --skip-extended-insert | exe/masking -c "$FILEDIR/masking.yml" > "$FILEDIR/tmp/masking_dumpfile.sql"
+  mysqldump -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" --complete-insert | exe/masking -c "$FILEDIR/masking.yml" > "$FILEDIR/tmp/masking_dumpfile.sql"
 
   mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" -e "CREATE DATABASE $MYSQL_ANONYMIZED_DBNAME;"
   mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_ANONYMIZED_DBNAME" < "$FILEDIR/tmp/masking_dumpfile.sql"

--- a/acceptance/run_test.sh
+++ b/acceptance/run_test.sh
@@ -23,6 +23,10 @@ main() {
   # import database
   mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" < "$FILEDIR/import_dumpfile.sql"
 
+  echo "mysql --version    : $(mysql --version)"
+  echo "mysqldump --version: $(mysqldump --version)"
+  echo
+
   #  masking & restore
   mysqldump -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" --complete-insert > "$FILEDIR/tmp/mysqldump_output.sql"
   if [[ "${DUMPFILE_DEBUG}" == "1" ]]; then

--- a/acceptance/run_test.sh
+++ b/acceptance/run_test.sh
@@ -5,6 +5,7 @@ set -C # Prevent output redirection using ‘>’, ‘>&’, and ‘<>’ from o
 if [[ "${TRACE-0}" == "1" ]]; then
     set -vx
 fi
+DUMPFILE_DEBUG="${DUMPFILE_DEBUG:-0}"
 
 MYSQL_HOST=${MYSQL_HOST:-localhost}
 MYSQL_USER=${MYSQL_USER:-root}
@@ -24,6 +25,12 @@ main() {
 
   #  masking & restore
   mysqldump -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" --complete-insert > "$FILEDIR/tmp/mysqldump_output.sql"
+  if [[ "${DUMPFILE_DEBUG}" == "1" ]]; then
+    echo "--- mysqldump output ---"
+    cat "$FILEDIR/tmp/mysqldump_output.sql"
+    echo "--- mysqldump output end ---"
+    echo ""
+  fi
   cat "$FILEDIR/tmp/mysqldump_output.sql" | exe/masking -c "$FILEDIR/masking.yml" > "$FILEDIR/tmp/masking_dumpfile.sql"
 
   mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" -e "CREATE DATABASE $MYSQL_ANONYMIZED_DBNAME;"

--- a/acceptance/run_test.sh
+++ b/acceptance/run_test.sh
@@ -23,7 +23,8 @@ main() {
   mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" < "$FILEDIR/import_dumpfile.sql"
 
   #  masking & restore
-  mysqldump -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" --complete-insert | exe/masking -c "$FILEDIR/masking.yml" > "$FILEDIR/tmp/masking_dumpfile.sql"
+  mysqldump -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DBNAME" --complete-insert > "$FILEDIR/tmp/mysqldump_output.sql"
+  cat "$FILEDIR/tmp/mysqldump_output.sql" | exe/masking -c "$FILEDIR/masking.yml" > "$FILEDIR/tmp/masking_dumpfile.sql"
 
   mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" -e "CREATE DATABASE $MYSQL_ANONYMIZED_DBNAME;"
   mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_ANONYMIZED_DBNAME" < "$FILEDIR/tmp/masking_dumpfile.sql"

--- a/docker-compose/acceptance_test.sh
+++ b/docker-compose/acceptance_test.sh
@@ -11,9 +11,10 @@ cd "$(dirname "$0")"
 MYSQL_VERSION=${1:-mysql80}
 DOCKER_COMPOSE_FILE=${2:-docker-compose.yml}
 TRACE=${TRACE:-0}
+DUMPFILE_DEBUG=${DUMPFILE_DEBUG:-0}
 
 main() {
-  docker-compose -f "../$DOCKER_COMPOSE_FILE" -f "./$MYSQL_VERSION.yml" run -e "MYSQL_HOST=$MYSQL_VERSION" -e "TRACE=$TRACE" app acceptance/run_test.sh
+  docker-compose -f "../$DOCKER_COMPOSE_FILE" -f "./$MYSQL_VERSION.yml" run -e "MYSQL_HOST=$MYSQL_VERSION" -e "TRACE=$TRACE" -e "DUMPFILE_DEBUG=$DUMPFILE_DEBUG" app acceptance/run_test.sh
 }
 
 main "$@"


### PR DESCRIPTION
fix #88

after the investigation, somehow `mysqldump` behavior looks changed. it output with many breaklines

```
INSERT INTO `users` (`id`, `string`, `email`, `integer`, `float`, `boolean`, `null`, `date`, `time`, `binary_or_blob`, `nullable_string`, `nullable_integer`) VALUES (1,'example@exa','test@example.com',1245,2.1,1,-321,NULL,NULL,'\\x92\0\0\0\0\0\0\0','abcde',NULL),
(2,'あいうえお','invalid@email',0,-23.4422,0,321,NULL,NULL,'\\x92\\x92\0\0\0',NULL,12),
(3,'+-l;a*&^%$','chikahiro@test.com',-1,21.2321,NULL,-231321,'2019-10-31','2019-10-31 16:27:21',NULL,'abc123',-123);
```

## todo
 - [ ] why it happens? make the regression test 
question: is `--net-buffer-length` relates? https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_net-buffer-length
 - [ ] fix it
